### PR TITLE
Improve type safety

### DIFF
--- a/_source/Fight.ts
+++ b/_source/Fight.ts
@@ -22,6 +22,7 @@ class Fight {
     UI.setRedrawFunction(() => { this.redraw(); });
     // this.player.setDeathFunc(() => { this.end(); });
     this.enemy.setDeathFunc(() => { this.end(); });
+    this.div = document.createElement('div');
     this.draw();
   }
 
@@ -47,11 +48,13 @@ class Fight {
       return;
     } else {
       let move = moveSequence.shift();
-      console.log("Move: " + move);
-      UI.fakeClick(this.enemyButtons[move]);
-      window.setTimeout(() => {
-        this.makeNextEnemyMove(moveSequence);
-      }, 750);
+      if (move) {
+        console.log("Move: " + move);
+        UI.fakeClick(this.enemyButtons[move]);
+        window.setTimeout(() => {
+          this.makeNextEnemyMove(moveSequence);
+        }, 750);
+      }
     }
   }
 

--- a/_source/Run.ts
+++ b/_source/Run.ts
@@ -31,12 +31,15 @@ class Run {
     }
 
     offerModifier(): void {
-        let m = modifiers.selectRandomUnseen(this.seenModifiers);
+        // TODO: don't do an unsafe assertion here
+        let m = modifiers.selectRandomUnseen(this.seenModifiers)!;
         UI.fillScreen(UI.renderModifier(m, this.player, () => this.nextEvent()));
     }
 
     startFight(): void {
-        let f = new Fight(this.player, enemies.selectRandomUnseen(this.seenEnemies));
+        // TODO: don't do an unsafe assertion here
+        let enemy = enemies.selectRandomUnseen(this.seenEnemies)!;
+        let f = new Fight(this.player, enemy);
         f.setEndCallback(() => this.nextEvent());
     }
 

--- a/_source/Tool.ts
+++ b/_source/Tool.ts
@@ -37,6 +37,7 @@ class Tool {
     this.modifiers = [];
     this.multiplier = 1;
     this.usesPerTurn = Infinity;
+    this.usesLeft = this.usesPerTurn;
     for (let i = 0; i < effects.length; i++) {
       let curr = effects[i];
       if (curr instanceof AbstractEffect) {

--- a/_source/UI.ts
+++ b/_source/UI.ts
@@ -60,7 +60,7 @@ class UI {
     elem.classList.remove('fakeclick');
     elem.classList.add('fakeclick');
     window.setTimeout(function() {
-      elem.onclick(new MouseEvent('click'));
+      elem.onclick!(new MouseEvent('click'));
       elem.classList.remove('fakeclick');
     }, 500);
   }
@@ -103,7 +103,7 @@ class UI {
     if (t.usesPerTurn < Infinity) {
       div.appendChild(UI.makeTextParagraph(`(${t.usesLeft} use(s) left this turn)`));
     }
-    if (c && i !== undefined) {
+    if (c && i !== undefined && target !== undefined) {
       let b = UI.makeButton('Use', function(e: MouseEvent) {
         c.useTool(i, target);
         UI.redraw();

--- a/_source/characters/TheGranddaughter.ts
+++ b/_source/characters/TheGranddaughter.ts
@@ -2,4 +2,4 @@
 /// <reference path="../ItemPool.ts" />
 /// <reference path="../tools.ts" />
 
-characters.add('kid', new Player('The Granddaughter', 15, 10, tools.get('wrench')));
+characters.add('kid', new Player('The Granddaughter', 15, 10, tools.get('wrench')!));

--- a/_source/enemies/Goldfish.ts
+++ b/_source/enemies/Goldfish.ts
@@ -3,5 +3,5 @@
 /// <reference path="../Enemy.ts" />
 
 enemies.add('goldfish',
-    new Enemy('Goldfish', 10, 5, tools.get('splash'))
+    new Enemy('Goldfish', 10, 5, tools.get('splash')!)
 );

--- a/_source/enemies/GoldfishWithAGun.ts
+++ b/_source/enemies/GoldfishWithAGun.ts
@@ -3,5 +3,5 @@
 /// <reference path="../Enemy.ts" />
 
 enemies.add('goldfishwithagun',
-    new Enemy('Goldfish With A Gun', 10, 5, tools.get('sixshooter'))
+    new Enemy('Goldfish With A Gun', 10, 5, tools.get('sixshooter')!)
 );

--- a/_source/util.ts
+++ b/_source/util.ts
@@ -1,10 +1,10 @@
-function appendText(text: string, node: HTMLElement = document.body) {
+function appendText(text: string, node: HTMLElement = document.body): void {
   const textnode = document.createTextNode(text);
   node.appendChild(textnode);
 }
 
 // Filter an array in-place
-function filterInPlace<T>(arr: T[], pred: (T) => boolean): void {
+function filterInPlace<T>(arr: T[], pred: (x: T) => boolean): void {
   let i = 0;
   let j = 0;
   while(i < arr.length) {

--- a/built.js
+++ b/built.js
@@ -1,3 +1,4 @@
+"use strict";
 var __extends = (this && this.__extends) || (function () {
     var extendStatics = function (d, b) {
         extendStatics = Object.setPrototypeOf ||
@@ -11,6 +12,13 @@ var __extends = (this && this.__extends) || (function () {
         d.prototype = b === null ? Object.create(b) : (__.prototype = b.prototype, new __());
     };
 })();
+var __spreadArrays = (this && this.__spreadArrays) || function () {
+    for (var s = 0, i = 0, il = arguments.length; i < il; i++) s += arguments[i].length;
+    for (var r = Array(s), k = 0, i = 0; i < il; i++)
+        for (var a = arguments[i], j = 0, jl = a.length; j < jl; j++, k++)
+            r[k] = a[j];
+    return r;
+};
 function appendText(text, node) {
     if (node === void 0) { node = document.body; }
     var textnode = document.createTextNode(text);
@@ -127,7 +135,7 @@ var UI = (function () {
         if (t.usesPerTurn < Infinity) {
             div.appendChild(UI.makeTextParagraph("(" + t.usesLeft + " use(s) left this turn)"));
         }
-        if (c && i !== undefined) {
+        if (c && i !== undefined && target !== undefined) {
             var b = UI.makeButton('Use', function (e) {
                 c.useTool(i, target);
                 UI.redraw();
@@ -278,7 +286,7 @@ var CombinationEffect = (function (_super) {
         return acc.join(' ');
     };
     CombinationEffect.prototype.clone = function () {
-        return new (CombinationEffect.bind.apply(CombinationEffect, [void 0].concat(this.effects.map(function (x) { return x.clone(); }))))();
+        return new (CombinationEffect.bind.apply(CombinationEffect, __spreadArrays([void 0], this.effects.map(function (x) { return x.clone(); }))))();
     };
     return CombinationEffect;
 }(AbstractEffect));
@@ -408,6 +416,7 @@ var Tool = (function () {
         this.modifiers = [];
         this.multiplier = 1;
         this.usesPerTurn = Infinity;
+        this.usesLeft = this.usesPerTurn;
         for (var i = 0; i < effects.length; i++) {
             var curr = effects[i];
             if (curr instanceof AbstractEffect) {
@@ -456,7 +465,7 @@ var Tool = (function () {
     };
     Tool.prototype.clone = function () {
         var effectsClones = this.effects.map(function (x) { return x.clone(); });
-        var t = new (Tool.bind.apply(Tool, [void 0, this.name, this.cost.clone()].concat(effectsClones)))();
+        var t = new (Tool.bind.apply(Tool, __spreadArrays([void 0, this.name, this.cost.clone()], effectsClones)))();
         t.usesPerTurn = this.usesPerTurn;
         t.multiplier = this.multiplier;
         t.modifiers = this.modifiers;
@@ -545,10 +554,10 @@ var Player = (function (_super) {
         for (var _i = 3; _i < arguments.length; _i++) {
             tools[_i - 3] = arguments[_i];
         }
-        return _super.apply(this, [name, health, energy].concat(tools)) || this;
+        return _super.apply(this, __spreadArrays([name, health, energy], tools)) || this;
     }
     Player.prototype.clone = function () {
-        return new (Player.bind.apply(Player, [void 0, this.name, this.health, this.energy].concat(this.tools.map(function (x) { return x.clone(); }))))();
+        return new (Player.bind.apply(Player, __spreadArrays([void 0, this.name, this.health, this.energy], this.tools.map(function (x) { return x.clone(); }))))();
     };
     return Player;
 }(Combatant));
@@ -610,10 +619,10 @@ var Enemy = (function (_super) {
         for (var _i = 3; _i < arguments.length; _i++) {
             tools[_i - 3] = arguments[_i];
         }
-        return _super.apply(this, [name, health, energy].concat(tools)) || this;
+        return _super.apply(this, __spreadArrays([name, health, energy], tools)) || this;
     }
     Enemy.prototype.clone = function () {
-        var copy = new (Enemy.bind.apply(Enemy, [void 0, this.name, this.health, this.energy].concat(this.tools.map(function (x) { return x.clone(); }))))();
+        var copy = new (Enemy.bind.apply(Enemy, __spreadArrays([void 0, this.name, this.health, this.energy], this.tools.map(function (x) { return x.clone(); }))))();
         copy.utilityFunction = this.utilityFunction;
         return copy;
     };
@@ -640,6 +649,7 @@ var Fight = (function () {
         this.enemyButtons = [];
         UI.setRedrawFunction(function () { _this.redraw(); });
         this.enemy.setDeathFunc(function () { _this.end(); });
+        this.div = document.createElement('div');
         this.draw();
     }
     Fight.prototype.setEndCallback = function (f) {
@@ -664,11 +674,13 @@ var Fight = (function () {
         }
         else {
             var move = moveSequence.shift();
-            console.log("Move: " + move);
-            UI.fakeClick(this.enemyButtons[move]);
-            window.setTimeout(function () {
-                _this.makeNextEnemyMove(moveSequence);
-            }, 750);
+            if (move) {
+                console.log("Move: " + move);
+                UI.fakeClick(this.enemyButtons[move]);
+                window.setTimeout(function () {
+                    _this.makeNextEnemyMove(moveSequence);
+                }, 750);
+            }
         }
     };
     Fight.prototype.endTurnButton = function () {
@@ -807,11 +819,11 @@ var ItemPool = (function () {
         for (var _i = 2; _i < arguments.length; _i++) {
             tags[_i - 2] = arguments[_i];
         }
-        this.items[key] = new (ItemPoolEntry.bind.apply(ItemPoolEntry, [void 0, key, item].concat(tags)))();
+        this.items[key] = new (ItemPoolEntry.bind.apply(ItemPoolEntry, __spreadArrays([void 0, key, item], tags)))();
         this.keys.push(key);
     };
     ItemPool.prototype.get = function (key) {
-        if (!this.items[key]) {
+        if (this.items[key] === undefined) {
             return null;
         }
         return this.items[key].get();
@@ -844,7 +856,7 @@ var ItemPool = (function () {
             }
         };
         var this_1 = this;
-        for (var _a = 0, _b = [tags].concat(fallbacks); _a < _b.length; _a++) {
+        for (var _a = 0, _b = __spreadArrays([tags], fallbacks); _a < _b.length; _a++) {
             var ts = _b[_a];
             var state_1 = _loop_1(ts);
             if (state_1 === "break")
@@ -866,7 +878,8 @@ var ItemPool = (function () {
         for (var _i = 2; _i < arguments.length; _i++) {
             fallbacks[_i - 2] = arguments[_i];
         }
-        return this.selectUnseenTags.apply(this, [seen, tags].concat(fallbacks)).map(function (k) { return _this.get(k); });
+        var unseen = this.selectUnseenTags.apply(this, __spreadArrays([seen, tags], fallbacks));
+        return unseen.map(function (k) { return _this.get(k); }).filter(function (x) { return x !== null; });
     };
     ItemPool.prototype.selectRandomUnseen = function (seen, tags) {
         if (tags === void 0) { tags = []; }
@@ -874,14 +887,14 @@ var ItemPool = (function () {
         for (var _i = 2; _i < arguments.length; _i++) {
             fallbacks[_i - 2] = arguments[_i];
         }
-        var unseen = this.selectUnseenTags.apply(this, [seen, tags].concat(fallbacks));
+        var unseen = this.selectUnseenTags.apply(this, __spreadArrays([seen, tags], fallbacks));
         var key = Random.fromArray(unseen);
         seen.push(key);
         return this.get(key);
     };
     ItemPool.prototype.getAll = function () {
         var _this = this;
-        return this.keys.map(function (x) { return _this.get(x); });
+        return this.keys.map(function (x) { return _this.get(x); }).filter(function (x) { return x !== null; });
     };
     return ItemPool;
 }());
@@ -923,7 +936,7 @@ var Game = (function () {
         ]));
     };
     Game.showCharSelect = function () {
-        UI.fillScreen(UI.renderCharacterSelect.apply(UI, [Game.newRun, Game.showTitle].concat(characters.getAll())));
+        UI.fillScreen(UI.renderCharacterSelect.apply(UI, __spreadArrays([Game.newRun, Game.showTitle], characters.getAll())));
         console.log(characters.getAll());
     };
     Game.newRun = function (character) {
@@ -986,7 +999,7 @@ var AI = (function () {
                 movesList.push(chosenMove);
             }
             var consequence = dummyBot.utilityFunction(dummyBot, dummyHuman);
-            if (consequence > this.bestSequenceScore) {
+            if (consequence >= this.bestSequenceScore) {
                 this.bestSequenceScore = consequence;
                 this.bestSequence = movesList;
             }
@@ -1030,7 +1043,8 @@ var Run = (function () {
     };
     Run.prototype.startFight = function () {
         var _this = this;
-        var f = new Fight(this.player, enemies.selectRandomUnseen(this.seenEnemies));
+        var enemy = enemies.selectRandomUnseen(this.seenEnemies);
+        var f = new Fight(this.player, enemy);
         f.setEndCallback(function () { return _this.nextEvent(); });
     };
     return Run;


### PR DESCRIPTION
Minor changes to improve type safety. This code compiles under the typechecker's strict mode. For example, the `items` in an `ItemPool` are now a `{ [key: string]: ItemPoolEntry<T, E> }` instead of just an `Object`.

Note that in the case of character/enemy creation, where we trust that a tool will be in the tool ItemPool, the result is simply asserted to be present.