### PR TITLE
Fix sameKind implementations

### DIFF
--- a/_source/statuses/ConfusionStatus.ts
+++ b/_source/statuses/ConfusionStatus.ts
@@ -26,7 +26,7 @@ class ConfusionStatus extends AbstractStatus {
     }
 
     sameKind(other: AbstractStatus): boolean {
-        return other instanceof EnergizedStatus;
+        return other instanceof ConfusionStatus;
     }
 
     clone(): ConfusionStatus {

--- a/_source/statuses/EnergizedStatus.ts
+++ b/_source/statuses/EnergizedStatus.ts
@@ -26,7 +26,7 @@ class EnergizedStatus extends AbstractStatus {
     }
 
     sameKind(other: AbstractStatus): boolean {
-        return other instanceof EnergyDebtStatus;
+        return other instanceof EnergizedStatus;
     }
 
     clone(): EnergizedStatus {


### PR DESCRIPTION
Two `sameKind` instances were misimplemented. This fixes the implementations while I think of a better way to do this.