### PR TITLE
Clean up coordinates and fix blocked calculations

### DIFF
--- a/_source/Coordinates.ts
+++ b/_source/Coordinates.ts
@@ -1,0 +1,34 @@
+// Coordinates, usually using the top left of the screen as the origin by
+// convention
+class Coordinates {
+    readonly x: number;
+    readonly y: number;
+
+    constructor(c: { x: number; y: number }) {
+        this.x = c.x;
+        this.y = c.y;
+    }
+
+    surroundingCoords(): Coordinates[] {
+        let offsets: [number, number][] = [[1, 0], [0, 1], [-1, 0], [0, -1]];
+        return offsets.map(o => this.applyOffset(o));
+    }
+
+    applyOffset(offset: [number, number]): Coordinates {
+        return new Coordinates({ x: this.x + offset[0], y: this.y + offset[1] });
+    }
+
+    calculateOffset(other: Coordinates): [number, number] {
+        return [other.x - this.x, other.y - this.y];
+    }
+
+    equals(other: Coordinates): boolean {
+        return this.x === other.x && this.y === other.y;
+    }
+
+    toString(): string {
+        return `(${this.x}, ${this.y})`;
+    }
+
+}
+

--- a/_source/Random.ts
+++ b/_source/Random.ts
@@ -24,8 +24,11 @@ class Random {
         return Random.intBetween(0, max);
     }
 
-    public static intCoord(width: number, height: number): [number, number] {
-        return [Random.intLessThan(width), Random.intLessThan(height)];
+    public static intCoord(width: number, height: number): Coordinates {
+        return new Coordinates({
+            x: Random.intLessThan(width),
+            y: Random.intLessThan(height)
+        });
     }
 
     public static fromArray<T>(arr: T[]): T {

--- a/_source/Run.ts
+++ b/_source/Run.ts
@@ -4,6 +4,7 @@
 class Run {
 
     player: Player;
+    playerCoordinates: Coordinates;
     seenEnemies: string[];
     seenModifiers: string[];
     seenTraits: string[];
@@ -12,6 +13,7 @@ class Run {
     constructor(player: Player) {
         this.player = player;
         this.player.setDeathFunc(() => Game.showGameOver(this));
+        this.playerCoordinates = new Coordinates( { x: 0, y: 0 } );
         this.numEvents = 0;
         this.seenEnemies = [];
         this.seenModifiers = [];
@@ -25,6 +27,7 @@ class Run {
     nextEvent(): void {
         this.numEvents++;
         let floor = new Floor(0, this);
+        this.playerCoordinates = floor.entranceRoom.coordinates;
         floor.redraw();
         // switch (this.numEvents % 2) {
         //     case 0:
@@ -57,6 +60,10 @@ class Run {
         let enemy = enemies.selectRandomUnseen(this.seenEnemies)!;
         let f = new Fight(this.player, enemy);
         f.setEndCallback(() => this.nextEvent());
+    }
+
+    movePlayer(coords: Coordinates): void {
+        this.playerCoordinates = coords;
     }
 
 }

--- a/_source/UI.ts
+++ b/_source/UI.ts
@@ -259,16 +259,21 @@ class UI {
     static renderRoom(room: Room) {
         const div: HTMLElement = UI.makeDiv("room");
         div.classList.add(room.getRoomType() + "-room");
-        let visible = room.hasPlayer || room.exits.some(e => e.hasPlayer);
+
+        let playerCoords = Game.currentRun.playerCoordinates;
+        let hasPlayer = room.coordinates.equals(playerCoords);
+        let exitHasPlayer = room.exits.some(e => e.coordinates.equals(playerCoords));
+        let visible = hasPlayer || exitHasPlayer;
+
         if (visible || room.visited) {
             div.classList.add("visible");
-            if (room.hasPlayer) {
+            if (hasPlayer) {
                 div.appendChild(UI.makeRoomIcon('player'));
             } else if (room.getRoomType() !== RoomType.Empty) {
                 div.appendChild(UI.makeRoomIcon(room.getRoomType()));
             }
         }
-        if (!room.hasPlayer && visible) {
+        if (!hasPlayer && visible) {
             div.onclick = function(e: MouseEvent) {
                 room.enter();
             };

--- a/_source/map/Floor.ts
+++ b/_source/map/Floor.ts
@@ -11,6 +11,7 @@ class Floor {
 
     roomCount: number;
     rooms: Array<Array<Room>>;
+    entranceRoom: Room;
 
     div: HTMLElement;
 
@@ -31,8 +32,8 @@ class Floor {
             y: Random.intLessThan(this.height)
         });
         let entranceRoom = new Room(this, entranceCoords, new EmptyRoomEvent(RoomType.Entrance));
-        entranceRoom.hasPlayer = true;
         entranceRoom.visited = true;
+        this.entranceRoom = entranceRoom;
 
         this.rooms[entranceCoords.y][entranceCoords.x] = entranceRoom;
         let assignableRooms = [];

--- a/_source/map/Floor.ts
+++ b/_source/map/Floor.ts
@@ -24,33 +24,35 @@ class Floor {
 
         this.roomCount = floorSettings.getNumRooms();
 
-        this.rooms = new Array<Array<Room>>(this.height);
-        for (let i = 0; i < this.rooms.length; i++) {
-            this.rooms[i] = new Array<Room>(this.width);
-        }
+        this.rooms = Arrays.generate(this.height, () => new Array<Room>(this.width));
 
-        let entranceCoords = [Random.intLessThan(this.height), Random.intLessThan(this.width)] as [number, number];
+        let entranceCoords = new Coordinates({
+            x: Random.intLessThan(this.width),
+            y: Random.intLessThan(this.height)
+        });
         let entranceRoom = new Room(this, entranceCoords, new EmptyRoomEvent(RoomType.Entrance));
         entranceRoom.hasPlayer = true;
         entranceRoom.visited = true;
 
-        this.rooms[entranceCoords[0]][entranceCoords[1]] = entranceRoom;
+        this.rooms[entranceCoords.y][entranceCoords.x] = entranceRoom;
         let assignableRooms = [];
         let maxRoomDistance = 0;
         for (let i = 0; i < this.roomCount - 1; i++) {
-            let roomIndex;
-            let newRoomIndex;
+            let roomCoords;
+            let newRoomCoords;
             do {
-                roomIndex = Random.intCoord(this.height, this.width);
-                if (this.rooms[roomIndex[0]][roomIndex[1]] !== undefined) {
+                roomCoords = Random.intCoord(this.height, this.width);
+                if (this.rooms[roomCoords.y][roomCoords.x] !== undefined) {
                     let newRoomOffset = Floor.randomDirectionOffset();
-                    newRoomIndex = [roomIndex[0] + newRoomOffset[0], roomIndex[1] + newRoomOffset[1]] as [number, number];
+                    newRoomCoords = roomCoords.applyOffset(newRoomOffset);
                 }
-            } while (!newRoomIndex || this.shouldGenNewRoom(newRoomIndex));
-            let entrance = this.rooms[roomIndex[0]][roomIndex[1]]
-            let newRoom = new Room(this, newRoomIndex, new EmptyRoomEvent(RoomType.Empty), entrance);
-            this.rooms[newRoomIndex[0]][newRoomIndex[1]] = newRoom;
-            this.rooms[roomIndex[0]][roomIndex[1]].exits.push(newRoom);
+            } while (!newRoomCoords || this.shouldGenNewRoom(newRoomCoords));
+
+            let entrance = this.rooms[roomCoords.y][roomCoords.x];
+            let newRoom = new Room(this, newRoomCoords, new EmptyRoomEvent(RoomType.Empty), entrance);
+            this.rooms[newRoomCoords.y][newRoomCoords.x] = newRoom;
+
+            this.rooms[roomCoords.y][roomCoords.x].exits.push(newRoom);
             assignableRooms.push(newRoom);
             maxRoomDistance = Math.max(maxRoomDistance, newRoom.distanceFromEntrance);
         }
@@ -87,13 +89,13 @@ class Floor {
         return [Math.cos(angle) << 0, Math.sin(angle) << 0];
     }
 
-    private shouldGenNewRoom(coord: [number, number]): boolean {
+    private shouldGenNewRoom(coord: Coordinates): boolean {
         if (!coord) {
             return false;
         }
-        let x = coord[0];
-        let y = coord[1];
-        return x <= -1 || x >= this.height || y <= -1 || y >= this.width || this.rooms[x][y] !== undefined;
+        let x = coord.x;
+        let y = coord.y;
+        return x <= -1 || x >= this.width || y <= -1 || y >= this.height || this.rooms[y][x] !== undefined;
     }
 
 }

--- a/_source/map/Room.ts
+++ b/_source/map/Room.ts
@@ -1,3 +1,4 @@
+/// <reference path="../Coordinates.ts" />
 /// <reference path="Floor.ts" />
 /// <reference path="RoomEvent.ts" />
 
@@ -6,8 +7,9 @@ class Room {
     // track of the total number here
     private static roomsEntered: number = 0;
 
+    // TODO: can this be decoupled?
     containerFloor: Floor;
-    coordinates: [number, number];
+    coordinates: Coordinates;
     exits: Room[];
     distanceFromEntrance: number;
     visited: boolean;
@@ -15,7 +17,7 @@ class Room {
     hasPlayer: boolean;
     roomEvent: RoomEvent;
 
-    constructor(containerFloor: Floor, coordinates: [number, number], roomEvent: RoomEvent, entrance?: Room, hasPlayer?: boolean) {
+    constructor(containerFloor: Floor, coordinates: Coordinates, roomEvent: RoomEvent, entrance?: Room, hasPlayer?: boolean) {
         this.containerFloor = containerFloor;
         this.coordinates = coordinates;
         this.roomEvent = roomEvent;
@@ -42,28 +44,26 @@ class Room {
     }
 
     // Get the coordinates of all exits from this room
-    getExitCoordinates(): [number, number][] {
+    getExitCoordinates(): Coordinates[] {
         return this.exits.map(e => e.coordinates);
     }
 
     // Note: includes coordinates off the map as blocked
-    getBlockedCoordinates(): [number, number][] {
-        let offsets = [[1, 0], [0, 1], [-1, 0], [0, -1]] as [number, number][];
-        let exitCoords: [number, number][] = this.exits.map(e => e.coordinates);
-        let surrounding: [number, number][] = offsets.map(o => {
-            return [this.coordinates[0] + o[0], this.coordinates[1] + o[1]];
-        });
-        return surrounding.filter(x => !exitCoords.some(c => c == x));
+    getBlockedCoordinates(): Coordinates[] {
+        let exitCoords = this.getExitCoordinates();
+        let surrounding = this.coordinates.surroundingCoords();
+        return surrounding.filter(x => !exitCoords.some(c => x.equals(c)));
     }
 
     // Returns offsets from this room that are not accessible from this room. An
-    // offset is one of [1, 0], [0, 1], [-1, 0], or [0, -1].
+    // offset is one of [1, 0], [0, 1], [-1, 0], or [0, -1], with [-1, -1]
+    // indicating "towards the top left".
     getBlockedOffsets(): [number, number][] {
         let offsets = [[1, 0], [0, 1], [-1, 0], [0, -1]] as [number, number][];
-        let exitCoords = this.exits.map(e => e.coordinates);
-        return offsets.filter(offset => {
-            let coord = [offset[0] + this.coordinates[0], offset[1] + this.coordinates[1]];
-            return !exitCoords.some(c => c == coord);
+        let exitCoords = this.getExitCoordinates();
+        return offsets.filter(o => {
+            let coord = this.coordinates.applyOffset(o);
+            return !exitCoords.some(c => coord.equals(c));
         });
     }
 

--- a/_source/map/Room.ts
+++ b/_source/map/Room.ts
@@ -13,17 +13,14 @@ class Room {
     exits: Room[];
     distanceFromEntrance: number;
     visited: boolean;
-    // TODO: invert this dependency, use coordinates instead
-    hasPlayer: boolean;
     roomEvent: RoomEvent;
 
-    constructor(containerFloor: Floor, coordinates: Coordinates, roomEvent: RoomEvent, entrance?: Room, hasPlayer?: boolean) {
+    constructor(containerFloor: Floor, coordinates: Coordinates, roomEvent: RoomEvent, entrance?: Room) {
         this.containerFloor = containerFloor;
         this.coordinates = coordinates;
         this.roomEvent = roomEvent;
         this.exits = entrance ? [entrance] : [];
         this.distanceFromEntrance = entrance ? entrance.distanceFromEntrance + 1 : 0;
-        this.hasPlayer = hasPlayer || false;
         this.visited = false;
     }
 
@@ -32,10 +29,9 @@ class Room {
     }
 
     enter(): void {
+        Game.currentRun.movePlayer(this.coordinates);
         Room.roomsEntered++;
-        this.exits.forEach(e => e.hasPlayer = false);
         this.visited = true;
-        this.hasPlayer = true;
         this.roomEvent = this.roomEvent.onRoomEnter(this, Room.roomsEntered);
     }
 


### PR DESCRIPTION
Cleaned up the coordinate and offset system to use a `Coordinates` instead of a `[number, number]`; many pieces of the code had the x and y switched, partially due to the fact that a two-dimensional array is usually indexed as `rooms[y][x]`. Removed manual addition of coordinates and moved these to methods inside of `Coordinates`. Fixed calculations for blocked directions and offsets using the new system.

Inverted dependency on `Room` state to keep track of where the player was via awkward `hasPlayer`. It doesn't make much sense for `Room`s to be responsible for managing player positions, and this made it difficult to get information about the player's position elsewhere; this information should be part of the central game state. Instead, the current `Run` keeps track of the player's coordinates, and the UI refers to the central state to see which room the player is in. This makes it easier to figure out what room the player is in in general, making future problems involving player position possible without having to dig through the rooms' state.