### PR TITLE
Remove logging statements causing bottlenecks

### DIFF
--- a/_source/Combatant.ts
+++ b/_source/Combatant.ts
@@ -207,10 +207,8 @@ abstract class Combatant {
     }
 
     private statusBookkeeping(): void {
-        console.log('bookkeeping...');
         this.statuses = this.statuses.filter(status => status.isValid());
         this.statuses = this.statuses.sort((a, b) => a.getSortingNumber() - b.getSortingNumber());
-        console.log(this.statuses);
     }
 
 }


### PR DESCRIPTION
Testing showed that even in the first turn of a fight against a Goldfish, the following function was called 17,672 times upon clicking "End Turn":

```typescript
private statusBookkeeping(): void {
    console.log('bookkeeping...');
    this.statuses = this.statuses.filter(status => status.isValid());
    this.statuses = this.statuses.sort((a, b) => a.getSortingNumber() - b.getSortingNumber());
    console.log(this.statuses);
}
```

Logging like this is _extremely_ expensive in such a tight place, to the point of crashing my browser when it did a particularly expensive exploration. `this.statuses` takes the browser especially long to log. Removing the two logging lines drastically improved performance.

We probably shouldn't leave so many `console.log`s lying around in the future.