### PR TITLE
Fix bug causing initial exits to not be visible

### DIFF
--- a/_source/Run.ts
+++ b/_source/Run.ts
@@ -30,12 +30,8 @@ class Run {
         this.currentFloor = new Floor(0, this);
         this.playerCoordinates = this.currentFloor.entranceRoom.coordinates;
         this.currentFloor.redraw();
-        // switch (this.numEvents % 2) {
-        //     case 0:
-        //         return this.offerModifier();
-        //     case 1:
-        //         return this.startFight();
-        // }
+        UI.announce(this.currentFloor.floorName);
+        this.currentFloor.entranceRoom.enter();
     }
 
     nextModifier(...tagSets: ModifierTags[][]): Modifier {

--- a/_source/map/Floor.ts
+++ b/_source/map/Floor.ts
@@ -6,6 +6,8 @@
 /// <reference path="../Random.ts" />
 
 class Floor {
+    floorName: string;
+
     width: number;
     height: number;
 
@@ -20,6 +22,7 @@ class Floor {
     constructor(level: number, currentRun: Run) {
         this.currentRun = currentRun
         let floorSettings = floors[level];
+        this.floorName = floorSettings.name;
         this.width = floorSettings.getWidth();
         this.height = floorSettings.getHeight();
 
@@ -67,8 +70,6 @@ class Floor {
         for (let i = 0; i < events.length && i < assignableRooms.length; i++) {
             assignableRooms[i].roomEvent = events[i];
         }
-        entranceRoom.enter();
-        UI.announce(floorSettings.name);
     }
 
     reveal(): void {


### PR DESCRIPTION
The entrance to a floor used to not actually be entered through `enter()`, so fiddling with the seen logic caused the initial exits to not be visible at first. The simplest way to fix this was just to actually enter the room and remove the redundant logic.