### PR TITLE
Add Direction enum to clear up some offset confusion

### DIFF
--- a/_source/Direction.ts
+++ b/_source/Direction.ts
@@ -1,0 +1,27 @@
+enum Direction {
+    Right,
+    Up,
+    Left,
+    Down,
+}
+
+namespace Directions {
+
+    export function values(): Direction[] {
+        return Object.keys(Direction).map(n => parseInt(n)).filter(n => !isNaN(n));
+    }
+
+    export function getOffset(dir: Direction): [number, number] {
+        switch (dir) {
+            case Direction.Up:
+                return [0, -1];
+            case Direction.Down:
+                return [0, 1];
+            case Direction.Left:
+                return [-1, 0];
+            case Direction.Right:
+                return [1, 0];
+        }
+    }
+
+}

--- a/_source/Random.ts
+++ b/_source/Random.ts
@@ -59,4 +59,10 @@ class Random {
         return arr;
     }
 
+    // Selects a random enum key from a numeric enum.
+    public static fromNumericEnum<T extends Record<number, U>, U>(e: T): T[keyof T] {
+        let keys = Object.keys(e).map(n => Number(n)).filter(n => !isNaN(n)) as unknown as T[keyof T][];
+        return Random.fromArray(keys);
+    }
+
 }

--- a/_source/UI.ts
+++ b/_source/UI.ts
@@ -265,7 +265,10 @@ class UI {
 
         if (room.seen || room.visited) {
             div.classList.add("visible");
-            room.getBlockedSides().forEach(side => div.classList.add(`blocked-${side}`));
+            room.getBlockedDirections().forEach(d => {
+                let className = `blocked-${Direction[d].toLowerCase()}`;
+                div.classList.add(className);
+            });
             if (hasPlayer) {
                 div.appendChild(UI.makeRoomIcon('player'));
             } else if (room.getRoomType() !== RoomType.Empty) {

--- a/_source/map/Floor.ts
+++ b/_source/map/Floor.ts
@@ -46,7 +46,8 @@ class Floor {
             do {
                 roomCoords = Random.intCoord(this.height, this.width);
                 if (this.rooms[roomCoords.y][roomCoords.x] !== undefined) {
-                    let newRoomOffset = Floor.randomDirectionOffset();
+                    let dir = Random.fromNumericEnum(Direction);
+                    let newRoomOffset = Directions.getOffset(dir);
                     newRoomCoords = roomCoords.applyOffset(newRoomOffset);
                 }
             } while (!newRoomCoords || this.shouldGenNewRoom(newRoomCoords));
@@ -91,11 +92,6 @@ class Floor {
 
     end(): void {
         document.body.removeChild(this.div);
-    }
-
-    private static randomDirectionOffset(): [number, number] {
-        let angle = Random.intLessThan(4) * Math.PI / 2;
-        return [Math.cos(angle) << 0, Math.sin(angle) << 0];
     }
 
     private shouldGenNewRoom(coord: Coordinates): boolean {

--- a/_source/map/Room.ts
+++ b/_source/map/Room.ts
@@ -54,26 +54,14 @@ class Room {
         return surrounding.filter(x => !exitCoords.some(c => x.equals(c)));
     }
 
-    // Returns offsets from this room that are not accessible from this room. An
-    // offset is one of [1, 0], [0, 1], [-1, 0], or [0, -1], with [-1, -1]
-    // indicating "towards the top left".
-    getBlockedOffsets(): [number, number][] {
-        let offsets = [[1, 0], [0, 1], [-1, 0], [0, -1]] as [number, number][];
+    getBlockedDirections(): Direction[] {
+        let directions = Directions.values();
         let exitCoords = this.getExitCoordinates();
-        return offsets.filter(o => {
-            let coord = this.coordinates.applyOffset(o);
+        return directions.filter(d => {
+            let offset = Directions.getOffset(d);
+            let coord = this.coordinates.applyOffset(offset);
             return !exitCoords.some(c => coord.equals(c));
         });
-    }
-
-    getBlockedSides(): string[] {
-        const sides = {
-            '0-1': 'up',
-            '01': 'down',
-            '-10': 'left',
-            '10': 'right'
-        }
-        return this.getBlockedOffsets().map(c => sides[`${c[0]}${c[1]}`]);
     }
 
     clearEvent(): void {


### PR DESCRIPTION
Stuff dealing with offsets related to directions ended up being really ugly, especially the way the CSS classes were derived from offsets. This introduces a `Direction` enum and associated functions in `Directions` in order to clean up this kind of code by abstracting over directional offsets.