### PR TITLE
Remove unnecessary type union varargs

### DIFF
--- a/_source/AbstractCombatPredicate.ts
+++ b/_source/AbstractCombatPredicate.ts
@@ -1,6 +1,6 @@
 /// <reference path="Combatant.ts" />
 abstract class AbstractCombatPredicate {
-    
+
     abstract toString(): string;
     abstract evaluate(target: Combatant, other: Combatant): boolean;
 

--- a/_source/Combatant.ts
+++ b/_source/Combatant.ts
@@ -16,17 +16,15 @@ abstract class Combatant {
     afterToolFunc: Function; //hacky, to make sure tools are done being used before fights end
     opponent: Combatant;
 
-    constructor(name: string, health: number, energy: number, ...others: (Tool | Trait)[]) {
+    constructor(name: string, health: number, energy: number, tools: Tool[], traits: Trait[]) {
         this.name = name;
         this.health = health;
         this.maxHealth = health;
         this.energy = energy;
         this.maxEnergy = energy;
-        //TODO: Ask Prindle if this is typesafe.
-        this.tools = <Tool[]> others.filter(x => x instanceof Tool);
+        this.tools = tools;
         this.traits = [];
         this.traitNames = [];
-        let traits = <Trait[]> others.filter(x => x instanceof Trait);
         traits.forEach(trait => this.addTrait(trait));
         this.deathFunc = function() {};
         this.afterToolFunc = function() {};

--- a/_source/Enemy.ts
+++ b/_source/Enemy.ts
@@ -8,8 +8,8 @@ class Enemy extends Combatant {
 
     utilityFunction: (Enemy, Player) => number;
 
-    constructor(name: string, health: number, energy: number, defaultUtilityFunction: (Enemy, Human) => number, ...others: (Tool | Trait)[]) {
-        super(name, health, energy, ...others);
+    constructor(name: string, health: number, energy: number, defaultUtilityFunction: (Enemy, Human) => number, tools: Tool[], traits: Trait[]) {
+        super(name, health, energy, tools, traits);
         if (defaultUtilityFunction == undefined) {
             this.utilityFunction = AiUtilityFunctions.cautiousUtility;
         } else {
@@ -20,8 +20,7 @@ class Enemy extends Combatant {
     }
 
     clone(): Enemy {
-        let others: (Tool | Trait)[] = [...this.tools, ...this.traits];
-        let copy = new Enemy(this.name, this.health, this.energy, this.utilityFunction, ...others.map(x => x.clone()));
+        let copy = new Enemy(this.name, this.health, this.energy, this.utilityFunction, this.tools.map(x => x.clone()), this.traits.map(x => x.clone()));
         copy.statuses = this.statuses.map(x => x.clone());
         copy.utilityFunction = this.utilityFunction;
         return copy;

--- a/_source/Player.ts
+++ b/_source/Player.ts
@@ -1,11 +1,11 @@
 ///<reference path="./Combatant.ts" />
 
 class Player extends Combatant {
-    
+
     currency: number;
 
-    constructor(name: string, health: number, energy: number, ...others: (Tool | Trait)[]) {
-        super(name, health, energy, ...others);
+    constructor(name: string, health: number, energy: number, tools: Tool[], traits: Trait[]) {
+        super(name, health, energy, tools, traits);
         this.currency = 0;
     }
 
@@ -18,8 +18,7 @@ class Player extends Combatant {
     }
 
     clone(): Player {
-        let others: (Tool | Trait)[] = [...this.tools, ...this.traits];
-        let p = new Player(this.name, this.health, this.energy, ...others.map(x => x.clone()));
+        let p = new Player(this.name, this.health, this.energy, this.tools.map(x => x.clone()), this.traits.map(x => x.clone()));
         p.statuses = this.statuses.map(x => x.clone());
         p.currency = this.currency;
         return p;

--- a/_source/characters/TheClone.ts
+++ b/_source/characters/TheClone.ts
@@ -3,8 +3,11 @@
 /// <reference path="../tools.ts" />
 
 characters.addSorted('clone', new Player('The Clone', 10, 10,
-    tools.get('windupraygun')!,
-    tools.get('confusionray')!,
-    tools.get('thermocouple')!,
-    tools.get('energizer')!,
+    [
+        tools.get('windupraygun')!,
+        tools.get('confusionray')!,
+        tools.get('thermocouple')!,
+        tools.get('energizer')!,
+    ],
+    []
 ), 1);

--- a/_source/characters/TheGranddaughter.ts
+++ b/_source/characters/TheGranddaughter.ts
@@ -3,9 +3,12 @@
 /// <reference path="../tools.ts" />
 
 characters.addSorted('kid', new Player('The Granddaughter', 15, 10,
-    tools.get('wrench')!,
-    tools.get('poisonray')!,
-    tools.get('lighter')!,
-    tools.get('jacket')!,
-    tools.get('thumbtack')!
+    [
+        tools.get('wrench')!,
+        tools.get('poisonray')!,
+        tools.get('lighter')!,
+        tools.get('jacket')!,
+        tools.get('thumbtack')!
+    ],
+    []
 ), 0);

--- a/_source/characters/TheReject.ts
+++ b/_source/characters/TheReject.ts
@@ -3,8 +3,11 @@
 /// <reference path="../tools.ts" />
 
 characters.addSorted('reject', new Player('The Reject', 10, 4,
-    tools.get('mutagens')!,
-    tools.get('boneclaws')!,
-    tools.get('rawhideskin')!,
-    tools.get('geneburst')!
+    [
+        tools.get('mutagens')!,
+        tools.get('boneclaws')!,
+        tools.get('rawhideskin')!,
+        tools.get('geneburst')!
+    ],
+    []
 ), 5);

--- a/_source/characters/TheShell.ts
+++ b/_source/characters/TheShell.ts
@@ -4,9 +4,13 @@
 /// <reference path="../traits.ts" />
 
 characters.addSorted('shell', new Player('The Shell', 10, 4,
-    tools.get('selfrepair')!,
-    tools.get('blaster')!,
-    tools.get('forcefield')!,
-    tools.get('recharge')!,
-    traits.get('voltaic')!
+     [
+         tools.get('selfrepair')!,
+         tools.get('blaster')!,
+         tools.get('forcefield')!,
+         tools.get('recharge')!,
+     ],
+     [
+         traits.get('voltaic')!
+     ]
 ), 4);

--- a/_source/enemies/CreepingCarpet.ts
+++ b/_source/enemies/CreepingCarpet.ts
@@ -4,5 +4,5 @@
 /// <reference path="../AiUtilityFunctions.ts" />
 
 enemies.add('creepingcarpet',
-    new Enemy('Creeping Carpet', 10, 2, AiUtilityFunctions.aggressiveUtility, tools.get('mycelium')!, tools.get('sporecloud')!),
+    new Enemy('Creeping Carpet', 10, 2, AiUtilityFunctions.aggressiveUtility, [tools.get('mycelium')!, tools.get('sporecloud')!], []),
 EnemyTags.level1);

--- a/_source/enemies/Goldfish.ts
+++ b/_source/enemies/Goldfish.ts
@@ -4,5 +4,5 @@
 /// <reference path="../AiUtilityFunctions.ts" />
 
 enemies.add('goldfish',
-    new Enemy('Goldfish', 10, 10, AiUtilityFunctions.cautiousUtility, tools.get('splash')!, tools.get('wrench')!),
+    new Enemy('Goldfish', 10, 10, AiUtilityFunctions.cautiousUtility, [tools.get('splash')!, tools.get('wrench')!], []),
 EnemyTags.level1);

--- a/_source/enemies/GoldfishWithAGun.ts
+++ b/_source/enemies/GoldfishWithAGun.ts
@@ -4,5 +4,5 @@
 /// <reference path="../AiUtilityFunctions.ts" />
 
 enemies.add('goldfishwithagun',
-    new Enemy('Goldfish With A Gun', 10, 5, AiUtilityFunctions.aggressiveUtility, tools.get('sixshooter')!),
+    new Enemy('Goldfish With A Gun', 10, 5, AiUtilityFunctions.aggressiveUtility, [tools.get('sixshooter')!], []),
 EnemyTags.level1);

--- a/_source/enemies/Greasertron.ts
+++ b/_source/enemies/Greasertron.ts
@@ -4,5 +4,5 @@
 /// <reference path="../AiUtilityFunctions.ts" />
 
 enemies.add('greasertron',
-    new Enemy('Greaser-Tron', 10, 6, AiUtilityFunctions.aggressiveUtility, tools.get('lighter')!, tools.get('switchblade')!, tools.get('comb')!),
+    new Enemy('Greaser-Tron', 10, 6, AiUtilityFunctions.aggressiveUtility, [tools.get('lighter')!, tools.get('switchblade')!, tools.get('comb')!], []),
 EnemyTags.level1);

--- a/_source/enemies/SlimeMoulder.ts
+++ b/_source/enemies/SlimeMoulder.ts
@@ -7,9 +7,13 @@
 
 enemies.add('slimemoulder',
     new Enemy('Slime Moulder', 16, 2, AiUtilityFunctions.aggressiveUtility,
-        modifiers.get('vampiric')!.apply(tools.get('mycelium')!),
-        tools.get('sporecloud')!,
-        tools.get('mitosisreflex')!,
-        traits.get('tough')!
+        [
+            modifiers.get('vampiric')!.apply(tools.get('mycelium')!),
+            tools.get('sporecloud')!,
+            tools.get('mitosisreflex')!,
+        ],
+        [
+            traits.get('tough')!
+        ]
     ),
 EnemyTags.level2);


### PR DESCRIPTION
Use of type-union varargs allows creation of new instances of Combatants to be slightly prettier at the expense of requiring extra traversals and type inspection in order to separate them out, which isn't extensible. Often, we clearly already have distinct sets of tools/traits which have to be merged, only to be unmerged later.

This just splits this into separate parameters and uses explicit arrays during instantiation, which also makes it clearer what is a tool and what isn't.