### PR TITLE
Add override annotations and fix BatteryStatus bug

### DIFF
--- a/_source/AI.ts
+++ b/_source/AI.ts
@@ -5,7 +5,7 @@ class AI {
     humanCopy: Player; // copy of the human-controlled combatant
     bestSequence: number[]; // the highest-utlity sequence that has been found
     bestSequenceScore: number; // the utility score of the best sequence
-    scoreFunction: (Enemy, Player) => number // the utility function used to assign scores to possible outcomes
+    scoreFunction: (e: Enemy, p: Player) => number // the utility function used to assign scores to possible outcomes
 
     constructor(aiCombatant: Enemy, humanCombatant: Player) {
         // TODO use the clone() method the actual enemy and player combatants
@@ -19,7 +19,7 @@ class AI {
         // check bot for status effects that change utility function
         // if more than one status implements an overriding utility function, use the one last in the sorted list of statuses
         let statuses = this.botCopy.statuses;
-        let preferenceOverride: (bot: Enemy, human: Player) => number;
+        let preferenceOverride: ((bot: Enemy, human: Player) => number) | undefined = undefined;
         statuses.forEach(function(status){
             if(status.overridenUtilityFunction != undefined) {
                 preferenceOverride = status.overridenUtilityFunction;

--- a/_source/AbstractStatus.ts
+++ b/_source/AbstractStatus.ts
@@ -6,7 +6,7 @@ enum StatusCallbacks {
     USE_TOOL = 'useTool',
     TAKE_DAMAGE = 'takeDamage',
     DIE = 'die',
-    //there's no callback for runOut since that shouldn't be called over all functions
+    //there's no callback for runsOut since that shouldn't be called over all functions
 }
 
 enum StatusFolds {

--- a/_source/Combatant.ts
+++ b/_source/Combatant.ts
@@ -14,7 +14,7 @@ abstract class Combatant {
     statuses: AbstractStatus[];
     deathFunc: Function;
     afterToolFunc: Function; //hacky, to make sure tools are done being used before fights end
-    opponent: Combatant;
+    opponent?: Combatant;
     imageSrc?: string;
 
     constructor(name: string, health: number, energy: number, tools: Tool[], traits: Trait[], image?: string) {
@@ -188,7 +188,9 @@ abstract class Combatant {
 
     removeStatus(remove: AbstractStatus): void {
         //call the runOut callback on all the ones that run out...
-        this.statuses.filter(status => status.sameKind(remove)).forEach(status => status.runsOut(this, this.opponent));
+        this.statuses.filter(status => status.sameKind(remove)).forEach(status => {
+            status.runsOut(this, this.opponent);
+        });
         this.statuses = this.statuses.filter(status => !status.sameKind(remove));
     }
 

--- a/_source/statuses/BatteryStatus.ts
+++ b/_source/statuses/BatteryStatus.ts
@@ -16,7 +16,7 @@ class BatteryStatus extends AbstractStatus {
         return false;
     }
 
-    runOut(affected: Combatant, other: Combatant): void {
+    runsOut(affected: Combatant, other: Combatant): void {
         affected.actuallyDie();
     }
 

--- a/_source/statuses/BatteryStatus.ts
+++ b/_source/statuses/BatteryStatus.ts
@@ -8,6 +8,7 @@ class BatteryStatus extends AbstractStatus {
         super(amount, StatusValidators.POSITIVE);
     }
 
+    @override(AbstractStatus)
     add(other: AbstractStatus): boolean {
         if (other instanceof BatteryStatus) {
             this.amount += other.amount;
@@ -16,34 +17,42 @@ class BatteryStatus extends AbstractStatus {
         return false;
     }
 
+    @override(AbstractStatus)
     runsOut(affected: Combatant, other: Combatant): void {
         affected.actuallyDie();
     }
 
+    @override(AbstractStatus)
     endTurn(affected: Combatant): void {
         this.amount--;
     }
 
+    @override(AbstractStatus)
     sameKind(other: AbstractStatus): boolean {
         return other instanceof BatteryStatus;
     }
 
+    @override(AbstractStatus)
     clone(): BatteryStatus {
         return new BatteryStatus(this.amount);
     }
 
+    @override(AbstractStatus)
     getName(): string {
         return 'battery';
     }
 
+    @override(AbstractStatus)
     getDescription(): string {
         return `If this hits zero, die instantly. Decrements by one each turn.`;
     }
 
+    @override(AbstractStatus)
     getSortingNumber(): number {
         return 10;
     }
 
+    @override(AbstractStatus)
     getUtility(): number {
         return this.amount * 10;
     }

--- a/_source/statuses/BurnStatus.ts
+++ b/_source/statuses/BurnStatus.ts
@@ -6,14 +6,17 @@ class BurnStatus extends AbstractStatus {
         super(amount, StatusValidators.POSITIVE);
     }
 
+    @override(AbstractStatus)
     useTool(affected: Combatant, other: Combatant) {
         affected.wound(this.amount);
     }
 
+    @override(AbstractStatus)
     endTurn(affected: Combatant, other: Combatant) {
         this.amount = 0;
     }
 
+    @override(AbstractStatus)
     add(other: AbstractStatus): boolean {
         if (other instanceof BurnStatus) {
             this.amount += other.amount;
@@ -22,26 +25,32 @@ class BurnStatus extends AbstractStatus {
         return false;
     }
 
+    @override(AbstractStatus)
     sameKind(other: AbstractStatus): boolean {
         return other instanceof BurnStatus;
     }
 
+    @override(AbstractStatus)
     clone(): BurnStatus {
         return new BurnStatus(this.amount);
     }
 
+    @override(AbstractStatus)
     getName(): string {
         return 'burn';
     }
 
+    @override(AbstractStatus)
     getDescription(): string {
         return `Take ${this.amount} damage whenever you use a tool this turn.`
     }
 
+    @override(AbstractStatus)
     getSortingNumber(): number {
         return 0;
     }
 
+    @override(AbstractStatus)
     getUtility(): number {
         return -5 * this.amount;
     }

--- a/_source/statuses/ConfusionStatus.ts
+++ b/_source/statuses/ConfusionStatus.ts
@@ -9,14 +9,17 @@ class ConfusionStatus extends AbstractStatus {
         super(amount, StatusValidators.POSITIVE);
     }
 
+    @override(AbstractStatus)
     endTurn(affected: Combatant, other: Combatant) {
         this.amount--;
     }
 
+    @override(AbstractStatus)
     overridenUtilityFunction(bot: Enemy, human: Player) {
         return AiUtilityFunctions.blindUtility(bot, human);
     }
 
+    @override(AbstractStatus)
     add(other: AbstractStatus): boolean {
         if (other instanceof ConfusionStatus) {
             this.amount += other.amount;
@@ -25,26 +28,32 @@ class ConfusionStatus extends AbstractStatus {
         return false;
     }
 
+    @override(AbstractStatus)
     sameKind(other: AbstractStatus): boolean {
         return other instanceof ConfusionStatus;
     }
 
+    @override(AbstractStatus)
     clone(): ConfusionStatus {
         return new ConfusionStatus(this.amount);
     }
 
+    @override(AbstractStatus)
     getName(): string {
         return 'confused';
     }
 
+    @override(AbstractStatus)
     getDescription(): string {
         return 'Make random moves instead of thinking strategically.';
     }
 
+    @override(AbstractStatus)
     getSortingNumber(): number {
         return 10;
     }
 
+    @override(AbstractStatus)
     getUtility(): number {
         return -5 * this.amount;
     }

--- a/_source/statuses/DefenseStatus.ts
+++ b/_source/statuses/DefenseStatus.ts
@@ -6,10 +6,12 @@ class DefenseStatus extends AbstractStatus {
         super(amount, StatusValidators.NONZERO);
     }
 
+    @override(AbstractStatus)
     damageTakenFold(acc: number): number {
         return Math.max(0, acc + this.amount);
     }
 
+    @override(AbstractStatus)
     add(other: AbstractStatus): boolean {
         if (other instanceof DefenseStatus) {
             this.amount += other.amount;
@@ -18,18 +20,22 @@ class DefenseStatus extends AbstractStatus {
         return false;
     }
 
+    @override(AbstractStatus)
     sameKind(other: AbstractStatus): boolean {
         return other instanceof DefenseStatus;
     }
 
+    @override(AbstractStatus)
     clone(): DefenseStatus {
         return new DefenseStatus(this.amount);
     }
 
+    @override(AbstractStatus)
     getName(): string {
         return 'defense';
     }
 
+    @override(AbstractStatus)
     getDescription(): string {
         if (this.amount > 0) {
             return `Take ${this.amount} less damage from attacks.`;
@@ -38,10 +44,12 @@ class DefenseStatus extends AbstractStatus {
         }
     }
 
+    @override(AbstractStatus)
     getSortingNumber(): number {
         return 0;
     }
 
+    @override(AbstractStatus)
     getUtility(): number {
         return 2 * this.amount;
     }

--- a/_source/statuses/DoomedStatus.ts
+++ b/_source/statuses/DoomedStatus.ts
@@ -8,6 +8,7 @@ class DoomedStatus extends AbstractStatus {
         super(amount, StatusValidators.POSITIVE);
     }
 
+    @override(AbstractStatus)
     add(other: AbstractStatus): boolean {
         if (other instanceof DoomedStatus) {
             this.amount += other.amount;
@@ -16,6 +17,7 @@ class DoomedStatus extends AbstractStatus {
         return false;
     }
 
+    @override(AbstractStatus)
     endTurn(affected: Combatant): void {
         this.amount--;
         if (this.amount === 0) {
@@ -23,18 +25,22 @@ class DoomedStatus extends AbstractStatus {
         }
     }
 
+    @override(AbstractStatus)
     sameKind(other: AbstractStatus): boolean {
         return other instanceof DoomedStatus;
     }
 
+    @override(AbstractStatus)
     clone(): DoomedStatus {
         return new DoomedStatus(this.amount);
     }
 
+    @override(AbstractStatus)
     getName(): string {
         return 'doomed';
     }
 
+    @override(AbstractStatus)
     getDescription(): string {
         if (this.amount === 1) {
             return `Die at the end of this turn.`;
@@ -42,10 +48,12 @@ class DoomedStatus extends AbstractStatus {
         return `Die in ${this.amount} turns.`;
     }
 
+    @override(AbstractStatus)
     getSortingNumber(): number {
         return 10;
     }
 
+    @override(AbstractStatus)
     getUtility(): number {
         //TODO: make this more accurate
         return -100 * Math.pow(2, -this.amount);

--- a/_source/statuses/EnergizedStatus.ts
+++ b/_source/statuses/EnergizedStatus.ts
@@ -9,14 +9,17 @@ class EnergizedStatus extends AbstractStatus {
         super(amount, StatusValidators.POSITIVE);
     }
 
+    @override(AbstractStatus)
     startTurn(affected: Combatant, other: Combatant) {
         affected.energy += this.amount; //otherwise it can get eaten by energy debt
     }
 
+    @override(AbstractStatus)
     endTurn(affected: Combatant, other: Combatant) {
         this.amount = 0;
     }
 
+    @override(AbstractStatus)
     add(other: AbstractStatus): boolean {
         if (other instanceof EnergizedStatus) {
             this.amount += other.amount;
@@ -25,26 +28,32 @@ class EnergizedStatus extends AbstractStatus {
         return false;
     }
 
+    @override(AbstractStatus)
     sameKind(other: AbstractStatus): boolean {
         return other instanceof EnergizedStatus;
     }
 
+    @override(AbstractStatus)
     clone(): EnergizedStatus {
         return new EnergizedStatus(this.amount);
     }
 
+    @override(AbstractStatus)
     getName(): string {
         return 'energized';
     }
 
+    @override(AbstractStatus)
     getDescription(): string {
         return `Start with ${this.amount} extra damage this turn.`;
     }
 
+    @override(AbstractStatus)
     getSortingNumber(): number {
         return 9;
     }
 
+    @override(AbstractStatus)
     getUtility(): number {
         return 2 * this.amount;
     }

--- a/_source/statuses/EnergyDebtStatus.ts
+++ b/_source/statuses/EnergyDebtStatus.ts
@@ -9,6 +9,7 @@ class EnergyDebtStatus extends AbstractStatus {
         super(amount, StatusValidators.POSITIVE);
     }
 
+    @override(AbstractStatus)
     energyGainedFold(acc: number): number {
         if (acc >= this.amount) {
           acc -= this.amount;
@@ -20,6 +21,7 @@ class EnergyDebtStatus extends AbstractStatus {
         }
     }
 
+    @override(AbstractStatus)
     add(other: AbstractStatus): boolean {
         if (other instanceof EnergyDebtStatus) {
             this.amount += other.amount;
@@ -28,27 +30,33 @@ class EnergyDebtStatus extends AbstractStatus {
         return false;
     }
 
+    @override(AbstractStatus)
     sameKind(other: AbstractStatus): boolean {
         return other instanceof EnergyDebtStatus;
     }
 
+    @override(AbstractStatus)
     clone(): EnergyDebtStatus {
         return new EnergyDebtStatus(this.amount);
     }
 
+    @override(AbstractStatus)
     getName(): string {
         return 'energy Debt';
     }
 
+    @override(AbstractStatus)
     getDescription(): string {
         //TODO: describe this better
         return `The next ${this.amount} Energy you gain will not count.`;
     }
 
+    @override(AbstractStatus)
     getSortingNumber(): number {
         return 10;
     }
 
+    @override(AbstractStatus)
     getUtility(): number {
         return -2 * this.amount;
     }

--- a/_source/statuses/FreezeStatus.ts
+++ b/_source/statuses/FreezeStatus.ts
@@ -6,14 +6,17 @@ class FreezeStatus extends AbstractStatus {
         super(amount, StatusValidators.POSITIVE);
     }
 
+    @override(AbstractStatus)
     useTool(affected: Combatant, other: Combatant) {
         affected.loseEnergy(this.amount);
     }
 
+    @override(AbstractStatus)
     endTurn(affected: Combatant, other: Combatant) {
         this.amount = 0;
     }
 
+    @override(AbstractStatus)
     add(other: AbstractStatus): boolean {
         if (other instanceof FreezeStatus) {
             this.amount += other.amount;
@@ -22,26 +25,32 @@ class FreezeStatus extends AbstractStatus {
         return false;
     }
 
+    @override(AbstractStatus)
     sameKind(other: AbstractStatus): boolean {
         return other instanceof FreezeStatus;
     }
 
+    @override(AbstractStatus)
     clone(): FreezeStatus {
         return new FreezeStatus(this.amount);
     }
 
+    @override(AbstractStatus)
     getName(): string {
         return 'freeze';
     }
 
+    @override(AbstractStatus)
     getDescription(): string {
         return `Lose ${this.amount} energy whenever you use a tool this turn.`
     }
 
+    @override(AbstractStatus)
     getSortingNumber(): number {
         return 0;
     }
 
+    @override(AbstractStatus)
     getUtility(): number {
         return -2 * this.amount;
     }

--- a/_source/statuses/FungalStatus.ts
+++ b/_source/statuses/FungalStatus.ts
@@ -7,10 +7,12 @@ class FungalStatus extends AbstractStatus {
         super(amount, StatusValidators.POSITIVE);
     }
 
+    @override(AbstractStatus)
     takeDamage(affected: Combatant, other: Combatant) {
         other.addStatus(new PoisonStatus(this.amount));
     }
 
+    @override(AbstractStatus)
     add(other: AbstractStatus): boolean {
         if (other instanceof FungalStatus) {
             this.amount += other.amount;
@@ -19,26 +21,32 @@ class FungalStatus extends AbstractStatus {
         return false;
     }
 
+    @override(AbstractStatus)
     sameKind(other: AbstractStatus): boolean {
         return other instanceof FungalStatus;
     }
 
+    @override(AbstractStatus)
     clone(): FungalStatus {
         return new FungalStatus(this.amount);
     }
 
+    @override(AbstractStatus)
     getName(): string {
         return 'fungal';
     }
 
+    @override(AbstractStatus)
     getDescription(): string {
         return `Opponent gains ${this.amount} poison whenever you take damage.`;
     }
 
+    @override(AbstractStatus)
     getSortingNumber(): number {
         return 0;
     }
 
+    @override(AbstractStatus)
     getUtility(): number {
         return this.amount;
     }

--- a/_source/statuses/PoisonStatus.ts
+++ b/_source/statuses/PoisonStatus.ts
@@ -6,11 +6,13 @@ class PoisonStatus extends AbstractStatus {
         super(amount, StatusValidators.POSITIVE);
     }
 
+    @override(AbstractStatus)
     startTurn(affected: Combatant, other: Combatant) {
         affected.directDamage(this.amount);
         this.amount--;
     }
 
+    @override(AbstractStatus)
     add(other: AbstractStatus): boolean {
         if (other instanceof PoisonStatus) {
             this.amount += other.amount;
@@ -19,18 +21,22 @@ class PoisonStatus extends AbstractStatus {
         return false;
     }
 
+    @override(AbstractStatus)
     sameKind(other: AbstractStatus): boolean {
         return other instanceof PoisonStatus;
     }
 
+    @override(AbstractStatus)
     clone(): PoisonStatus {
         return new PoisonStatus(this.amount);
     }
 
+    @override(AbstractStatus)
     getName(): string {
         return 'poison';
     }
 
+    @override(AbstractStatus)
     getDescription(): string {
         if (this.amount === 1) {
             return `Take 1 damage at the end of this turn.`;
@@ -39,10 +45,12 @@ class PoisonStatus extends AbstractStatus {
         }
     }
 
+    @override(AbstractStatus)
     getSortingNumber(): number {
         return 0;
     }
 
+    @override(AbstractStatus)
     getUtility(): number {
         return -1 * ((this.amount) * (this.amount + 1))/2;
     }

--- a/_source/statuses/RotStatus.ts
+++ b/_source/statuses/RotStatus.ts
@@ -6,10 +6,12 @@ class RotStatus extends AbstractStatus {
         super(amount, StatusValidators.POSITIVE);
     }
 
+    @override(AbstractStatus)
     endTurn(affected: Combatant, other: Combatant) {
         affected.directDamage(this.amount);
     }
 
+    @override(AbstractStatus)
     add(other: AbstractStatus): boolean {
         if (other instanceof RotStatus) {
             this.amount += other.amount;
@@ -18,26 +20,32 @@ class RotStatus extends AbstractStatus {
         return false;
     }
 
+    @override(AbstractStatus)
     sameKind(other: AbstractStatus): boolean {
         return other instanceof RotStatus;
     }
 
+    @override(AbstractStatus)
     clone(): RotStatus {
         return new RotStatus(this.amount);
     }
 
+    @override(AbstractStatus)
     getName(): string {
         return 'rot';
     }
 
+    @override(AbstractStatus)
     getDescription(): string {
       return `Take ${this.amount} damage at the end of every turn.`;
     }
 
+    @override(AbstractStatus)
     getSortingNumber(): number {
         return 0;
     }
 
+    @override(AbstractStatus)
     getUtility(): number {
         return -10 * this.amount;
     }

--- a/_source/statuses/ShieldStatus.ts
+++ b/_source/statuses/ShieldStatus.ts
@@ -8,6 +8,7 @@ class ShieldStatus extends AbstractStatus {
         super(amount, StatusValidators.POSITIVE);
     }
 
+    @override(AbstractStatus)
     damageTakenFold(acc: number): number {
         if (acc >= this.amount) {
           acc -= this.amount;
@@ -19,6 +20,7 @@ class ShieldStatus extends AbstractStatus {
         }
     }
 
+    @override(AbstractStatus)
     add(other: AbstractStatus): boolean {
         if (other instanceof ShieldStatus) {
             this.amount += other.amount;
@@ -27,26 +29,32 @@ class ShieldStatus extends AbstractStatus {
         return false;
     }
 
+    @override(AbstractStatus)
     sameKind(other: AbstractStatus): boolean {
         return other instanceof ShieldStatus;
     }
 
+    @override(AbstractStatus)
     clone(): ShieldStatus {
         return new ShieldStatus(this.amount);
     }
 
+    @override(AbstractStatus)
     getName(): string {
         return 'shield';
     }
 
+    @override(AbstractStatus)
     getDescription(): string {
         return `Block ${this.amount} damage.`;
     }
 
+    @override(AbstractStatus)
     getSortingNumber(): number {
         return 10;
     }
 
+    @override(AbstractStatus)
     getUtility(): number {
         return this.amount;
     }

--- a/_source/statuses/StrengthStatus.ts
+++ b/_source/statuses/StrengthStatus.ts
@@ -6,10 +6,12 @@ class StrengthStatus extends AbstractStatus {
         super(amount, StatusValidators.NONZERO);
     }
 
+    @override(AbstractStatus)
     damageDealtFold(acc: number): number {
         return Math.max(1, acc + this.amount);
     }
 
+    @override(AbstractStatus)
     add(other: AbstractStatus): boolean {
         if (other instanceof StrengthStatus) {
             this.amount += other.amount;
@@ -18,18 +20,22 @@ class StrengthStatus extends AbstractStatus {
         return false;
     }
 
+    @override(AbstractStatus)
     sameKind(other: AbstractStatus): boolean {
         return other instanceof StrengthStatus;
     }
 
+    @override(AbstractStatus)
     clone(): StrengthStatus {
         return new StrengthStatus(this.amount);
     }
 
+    @override(AbstractStatus)
     getName(): string {
         return 'strength';
     }
 
+    @override(AbstractStatus)
     getDescription(): string {
         if (this.amount > 0) {
             return `Deal ${this.amount} more damage whenever you attack.`;
@@ -38,10 +44,12 @@ class StrengthStatus extends AbstractStatus {
         }
     }
 
+    @override(AbstractStatus)
     getSortingNumber(): number {
         return 0;
     }
 
+    @override(AbstractStatus)
     getUtility(): number {
         return 2 * this.amount;
     }

--- a/_source/statuses/SurviveStatus.ts
+++ b/_source/statuses/SurviveStatus.ts
@@ -6,11 +6,13 @@ class SurviveStatus extends AbstractStatus {
         super(amount, StatusValidators.POSITIVE);
     }
 
+    @override(AbstractStatus)
     die(affected: Combatant, other: Combatant): void {
         affected.health = 1;
         this.amount--;
     }
 
+    @override(AbstractStatus)
     add(other: AbstractStatus): boolean {
         if (other instanceof SurviveStatus) {
             this.amount += other.amount;
@@ -19,18 +21,22 @@ class SurviveStatus extends AbstractStatus {
         return false;
     }
 
+    @override(AbstractStatus)
     sameKind(other: AbstractStatus): boolean {
         return other instanceof SurviveStatus;
     }
 
+    @override(AbstractStatus)
     clone(): SurviveStatus {
         return new SurviveStatus(this.amount);
     }
 
+    @override(AbstractStatus)
     getName(): string {
         return 'survive';
     }
 
+    @override(AbstractStatus)
     getDescription(): string {
         if (this.amount === 1) {
             return `Survive the next killing blow.`;
@@ -39,10 +45,12 @@ class SurviveStatus extends AbstractStatus {
         }
     }
 
+    @override(AbstractStatus)
     getSortingNumber(): number {
         return 0;
     }
 
+    @override(AbstractStatus)
     getUtility(): number {
         return 10 * this.amount;
     }

--- a/_source/tsconfig.json
+++ b/_source/tsconfig.json
@@ -2,7 +2,8 @@
   "compilerOptions": {
     "removeComments": true,
     "outFile": "../built.js",
-    "target": "ES5"
+    "target": "ES5",
+    "experimentalDecorators": true
   },
   "include": [
     "app.ts",

--- a/_source/util.ts
+++ b/_source/util.ts
@@ -16,3 +16,12 @@ function filterInPlace<T>(arr: T[], pred: (x: T) => boolean): void {
     }
     arr.length = j;
 }
+
+// Enforces that a method is overriden from the superclass
+// Used as an annotation: @override(superclass)
+const override = <S>(superclass: { prototype: S }) =>
+    <K extends keyof S, P extends Pick<S, K>>(
+        proto: P,
+        fields: K,
+        descr: TypedPropertyDescriptor<S[K]>,
+    ) => { }


### PR DESCRIPTION
`BatteryStatus` had a bug where it tried to override `runsOut` from `AbstractStatus`, but it accidentally named it `runOut`. Because `runsOut` wasn't abstract and was defined to be empty, the compiler couldn't catch that this wasn't overriding anything. In Java, you can use `@Override` to verify that your method is actually overriding something, but Typescript unfortunately doesn't have anything like that.

Fortunately, it's possible to implement one in user-space, like [this](https://github.com/nprindle/inheritance/blob/a4a965a4425be1d90d019afedc87abf9d80b61bc/_source/util.ts#L22). You can use it like so:
```typescript
abstract class Super {
    abstract foo(): void;
}

class Sub extends Super {
    // Ok
    @override(Super)
    foo(): void {

    }

    // Compile-time error; `bar` does not override anything from Super
    @override(Super)
    bar(): void {

    }
}
```

This also adds annotations for overridden members to all subclasses of `AbstractStatus`, as well as a few miscellaneous fixes for additional safety.