### PR TITLE
Implement LocalStorage for settings, fix audioElems indexing

### DIFF
--- a/_source/Save.ts
+++ b/_source/Save.ts
@@ -1,8 +1,9 @@
 class Save {
     static isSupported: boolean = window.localStorage !== undefined && window.localStorage !== null;
 
-    // The name of the key to use to store note data in LocalStorage
+    // The names of the keys to use in LocalStorage
     private static lsNoteKey = 'unlocked_notes';
+    private static lsSettingsKey = 'settings';
 
     // Saves the current state of the notes to local storage, if it is
     // available. Returns true if the store succeeded. The return value usually
@@ -54,10 +55,40 @@ class Save {
     }
 
     static saveSettings(): boolean {
+        if (Save.isSupported) {
+            let obj = Settings.dumpToObject();
+            let json = JSON.stringify(obj);
+            window.localStorage.setItem(Save.lsSettingsKey, json);
+            return true
+        }
         return false;
     }
 
     static loadSettings(): boolean {
+        if (Save.isSupported) {
+            try {
+                let contents = window.localStorage.getItem(Save.lsSettingsKey);
+                if (contents === null) {
+                    return true;
+                }
+                let obj: any = JSON.parse(contents);
+                // We can't inspect the keys yet; we rely on
+                // Settings.loadFromObject for that
+                if (isSettingsOptions(obj)) {
+                    Settings.loadFromObject(obj);
+                    return true;
+                } else {
+                    return false;
+                }
+            } catch (e) {
+                // Failed JSON parsing throws a SyntaxError
+                if (e instanceof SyntaxError) {
+                    return false;
+                } else {
+                    throw e;
+                }
+            }
+        }
         return false;
     }
 

--- a/_source/Settings.ts
+++ b/_source/Settings.ts
@@ -1,0 +1,45 @@
+// The type that should be parsed from the JSON in LocalStorage
+// TODO: try to reify the keys of Settings so there's no duplication here
+type SettingsOptions = {
+    volumePercent: number;
+};
+
+// Type predicate to check if a value is an object with the necessary fields to
+// be a SettingsOptions
+function isSettingsOptions(x: any): x is SettingsOptions {
+    if (typeof(x) === "object" && x !== null) {
+        let y = x as SettingsOptions;
+        return y.volumePercent !== undefined;
+    } else {
+        return false;
+    }
+}
+
+class Settings {
+    // Percentage from 0 to 100, defaulting to 100
+    private static volumePercent: number = 100;
+
+    public static getVolumePercent(): number {
+        return Settings.volumePercent;
+    }
+
+    // Set the volume percentage setting
+    public static setVolumePercent(percent: number): void {
+        Settings.volumePercent = percent;
+        SoundManager.setVolume(percent / 100);
+    }
+
+    // Load settings from an object and return true, if necessary properties are
+    // present. If not, return false.
+    public static loadFromObject(obj: SettingsOptions): void {
+        Settings.setVolumePercent(obj.volumePercent);
+    }
+
+    public static dumpToObject(): SettingsOptions {
+        return {
+            volumePercent: Settings.volumePercent
+        };
+    }
+
+}
+

--- a/_source/SoundManager.ts
+++ b/_source/SoundManager.ts
@@ -6,18 +6,22 @@ enum SoundEffects {
 
 class SoundManager {
 
-    //TODO: make indexing better
-    static audioElems: Record<string, HTMLAudioElement>;
+    static audioElems: Record<SoundEffects, HTMLAudioElement>;
 
     static init(): void {
-        this.audioElems = {};
+        let newAudioElement = () => document.createElement('audio');
+        this.audioElems = {
+            'noise.ogg': newAudioElement(),
+            'Modifier.ogg': newAudioElement(),
+            'Trait.ogg': newAudioElement(),
+        };
         let container: HTMLElement = document.getElementById('audio');
         Object.keys(SoundEffects).forEach(key => {
-            let filename: string = `assets/sfx/${SoundEffects[key]}`;
-            let audio: HTMLAudioElement = document.createElement('audio');
+            let filename: string = SoundEffects[key];
+            let filepath: string = `assets/sfx/${filename}`;
+            let audio = this.audioElems[filename];
             audio.preload = 'auto';
-            audio.src = filename;
-            this.audioElems[SoundEffects[key]] = audio;
+            audio.src = filepath;
             container.appendChild(audio);
         });
     }

--- a/_source/SoundManager.ts
+++ b/_source/SoundManager.ts
@@ -26,6 +26,8 @@ class SoundManager {
         });
     }
 
+    // Set the absolute volume (not as a percentage). Note: this does not change
+    // the game settings; use Settings.setVolumePercent for that.
     static setVolume(volume: number): void {
         Object.keys(SoundEffects).forEach(key => {
             this.audioElems[SoundEffects[key]].volume = volume;

--- a/_source/UI.ts
+++ b/_source/UI.ts
@@ -388,9 +388,11 @@ class UI {
     static renderSettings(exit: Function): HTMLElement {
         const div = UI.makeDiv('settings');
         div.appendChild(UI.makeHeader('Settings'));
-        div.appendChild(UI.makeSlider('Volume', 0, 100, 100, (t) => {
-            SoundManager.setVolume(parseInt(t.value) / 100);
+        let volume = Settings.getVolumePercent();
+        div.appendChild(UI.makeSlider('Volume', 0, 100, volume, t => {
+            Settings.setVolumePercent(parseInt(t.value));
             SoundManager.playSoundEffect(SoundEffects.Noise);
+            Save.saveSettings();
         }));
         div.appendChild(UI.makeButton('Back', exit));
         return div;

--- a/_source/app.ts
+++ b/_source/app.ts
@@ -1,4 +1,5 @@
 /// <reference path="util.ts" />
+/// <reference path="Settings.ts" />
 /// <reference path="UI.ts" />
 /// <reference path="SoundManager.ts" />
 /// <reference path="Player.ts" />
@@ -16,6 +17,8 @@
 window.onload = function() {
     //initialize sound manager
     SoundManager.init();
+    // Load any cached settings
+    Save.loadSettings();
     // Load note data
     NotePool.reloadAllNotes();
     // Try to load any unlocked notes if present


### PR DESCRIPTION
Adds a `Settings` class that `Save` can use to cache settings in LocalStorage. Currently, the volume slider is the only available setting. Also changes the UI's volume controls to use the new `Settings.setVolumePercent` volume controls, instead of setting directly with `SoundManager.setVolume`; the former now updates the settings and the volume, while the latter only updates the volume.

The API here could use a little work; `SettingsOptions` represents the JSON structure that should be parsed from the storage, but it should optimally be able to be derived from `Settings` automatically instead of needing the type predicate `isSettingsOptions`, although I'm not sure this kind of reification is possible. It's also still a little confusing where load/save calls should occur.

Additionally, this also fixes the indexing of `SoundManager.audioElems` to be typesafe with respect to its keys, and does a little reordering of `SoudnManager.init()` to remove the partiality of their initialization.