### PR TITLE
enemy ai adjusted to be more defensive

### DIFF
--- a/_source/enemies/CreepingCarpet.ts
+++ b/_source/enemies/CreepingCarpet.ts
@@ -4,5 +4,5 @@
 /// <reference path="../AiUtilityFunctions.ts" />
 
 enemies.add('creepingcarpet',
-    new Enemy('Creeping Carpet', 10, 2, AiUtilityFunctions.aggressiveUtility, [tools.get('mycelium')!, tools.get('sporecloud')!], []),
+    new Enemy('Creeping Carpet', 10, 2, AiUtilityFunctions.cautiousUtility, [tools.get('mycelium')!, tools.get('sporecloud')!], []),
 EnemyTags.level1);

--- a/_source/enemies/Greasertron.ts
+++ b/_source/enemies/Greasertron.ts
@@ -4,5 +4,5 @@
 /// <reference path="../AiUtilityFunctions.ts" />
 
 enemies.add('greasertron',
-    new Enemy('Greaser-Tron', 10, 6, AiUtilityFunctions.aggressiveUtility, [tools.get('lighter')!, tools.get('switchblade')!, tools.get('comb')!], []),
+    new Enemy('Greaser-Tron', 10, 6, AiUtilityFunctions.cautiousUtility, [tools.get('lighter')!, tools.get('switchblade')!, tools.get('comb')!], []),
 EnemyTags.level1);

--- a/_source/enemies/SlimeMoulder.ts
+++ b/_source/enemies/SlimeMoulder.ts
@@ -6,7 +6,7 @@
 /// <reference path="../AiUtilityFunctions.ts" />
 
 enemies.add('slimemoulder',
-    new Enemy('Slime Moulder', 16, 2, AiUtilityFunctions.aggressiveUtility,
+    new Enemy('Slime Moulder', 16, 2, AiUtilityFunctions.cautiousUtility,
         [
             tools.get('mycelium')!,
             tools.get('sporecloud')!,


### PR DESCRIPTION
Most enemies were set to Aggressive AI, so they cared very little about defending their own health compared to damaging the player. "Cautious" AI settings should be the default for most enemies, so that they will heal themselves and avoid self-injuring. For some enemy types, we may want to even switch to "defensive", which will heal itself even if that means passing up the opportunity to attack.