### PR TITLE
Give walls smoother corners, switch to border shadows

### DIFF
--- a/_source/UI.ts
+++ b/_source/UI.ts
@@ -378,7 +378,7 @@ class UI {
         let shadows = room.getBlockedDirections().map(d => UI.directionToBoxShadow(d, 4, 'black'));
         div.style['box-shadow'] = shadows.join(', ');
 
-        // Apply invisible element in order to exploit it for it's ::before and
+        // Apply invisible element in order to exploit it for its ::before and
         // ::after
         const cornerDiv: HTMLElement = UI.makeDiv("room-corners");
         div.appendChild(cornerDiv);

--- a/_source/UI.ts
+++ b/_source/UI.ts
@@ -359,10 +359,6 @@ class UI {
 
         if (room.seen || room.visited) {
             div.classList.add("visible");
-            room.getBlockedDirections().forEach(d => {
-                let className = `blocked-${Direction[d].toLowerCase()}`;
-                div.classList.add(className);
-            });
             if (hasPlayer) {
                 div.appendChild(UI.makeRoomIcon(RoomIcon.PLAYER));
             } else if (room.getIcon() !== RoomIcon.NONE) {
@@ -379,7 +375,30 @@ class UI {
         } else {
             div.classList.add("unvisited");
         }
+        let shadows = room.getBlockedDirections().map(d => UI.directionToBoxShadow(d, 4, 'black'));
+        div.style['box-shadow'] = shadows.join(', ');
+
+        // Apply invisible element in order to exploit it for it's ::before and
+        // ::after
+        const cornerDiv: HTMLElement = UI.makeDiv("room-corners");
+        div.appendChild(cornerDiv);
+
         return div;
+    }
+
+    // Convert a direction to the string representing the value of a box shadow
+    // CSS property of a given width in pixels to make a border on that side
+    static directionToBoxShadow(dir: Direction, width: number, color: string): string {
+        switch (dir) {
+            case Direction.Right:
+                return `inset -${width}px 0px 0px 0px ${color}`;
+            case Direction.Up:
+                return `inset 0px ${width}px 0px 0px ${color}`;
+            case Direction.Left:
+                return `inset ${width}px 0px 0px 0px ${color}`;
+            case Direction.Down:
+                return `inset 0px -${width}px 0px 0px ${color}`;
+        }
     }
 
     static renderMainTitle(): HTMLElement {

--- a/_source/map/Floor.ts
+++ b/_source/map/Floor.ts
@@ -98,6 +98,10 @@ class Floor {
         document.body.removeChild(this.div);
     }
 
+    getRoomAt(coords: Coordinates): Room | undefined {
+        return this.rooms[coords.y] && this.rooms[coords.y][coords.x];
+    }
+
     private shouldGenNewRoom(coord: Coordinates): boolean {
         if (!coord) {
             return false;

--- a/styles.css
+++ b/styles.css
@@ -388,21 +388,50 @@ button.endturn:active {
 }
 
 .room {
-    border: 3px solid transparent;
+    border-color: transparent;
 }
 
-.blocked-left {
-    border-left: 3px solid black;
+.room::before {
+    content: "";
+    position: absolute;
+    width: 0px;
+    height: 0px;
+    top: 0;
+    left: 0;
+    border-top: 4px solid black;
+    border-right: 4px solid transparent;
 }
 
-.blocked-right {
-    border-right: 3px solid black;
+.room::after {
+    content: "";
+    position: absolute;
+    width: 0px;
+    height: 0px;
+    top: 0;
+    right: 0;
+    border-top: 4px solid black;
+    border-left: 4px solid transparent;
 }
 
-.blocked-up {
-    border-top: 3px solid black;
+.room-corners::before {
+    content: "";
+    position: absolute;
+    width: 0px;
+    height: 0px;
+    bottom: 0;
+    left: 0;
+    border-left: 4px solid black;
+    border-top: 4px solid transparent;
 }
 
-.blocked-down {
-    border-bottom: 3px solid black;
+.room-corners::after {
+    content: "";
+    position: absolute;
+    width: 0px;
+    height: 0px;
+    bottom: 0;
+    right: 0;
+    border-right: 4px solid black;
+    border-top: 4px solid transparent;
 }
+


### PR DESCRIPTION
Switches to using border shadows for walls in order to prevent the annoying mitering with transparent borders. Uses zero-width boxes with mitered borders to create smoother triangle corners, so that corners aren't so jarring. This also lets you look ahead a little to see corners coming up.