### PR TITLE
Settings, saving, and util.ts cleanup

### DIFF
--- a/_source/Arrays.ts
+++ b/_source/Arrays.ts
@@ -12,4 +12,17 @@ class Arrays {
         return result;
     }
 
+    public static filterInPlace<T>(arr: T[], pred: (x: T) => boolean): void {
+        let i = 0;
+        let j = 0;
+        while (i < arr.length) {
+            const x = arr[i];
+            if (pred(x)) {
+                arr[j++] = x;
+            }
+            i++;
+        }
+        arr.length = j;
+    }
+
 }

--- a/_source/Enemy.ts
+++ b/_source/Enemy.ts
@@ -8,9 +8,9 @@ class Enemy extends Combatant {
     lootMoney: number;
     isFinalBoss: boolean; //if this is true, game ends when this guy guys
 
-    utilityFunction: (Enemy, Player) => number;
+    utilityFunction: (e: Enemy, p: Player) => number;
 
-    constructor(name: string, health: number, energy: number, defaultUtilityFunction: (Enemy, Human) => number, tools: Tool[], traits: Trait[], image?: string) {
+    constructor(name: string, health: number, energy: number, defaultUtilityFunction: (e: Enemy, p: Player) => number, tools: Tool[], traits: Trait[], image?: string) {
         super(name, health, energy, tools, traits, image);
         if (defaultUtilityFunction == undefined) {
             this.utilityFunction = AiUtilityFunctions.cautiousUtility;

--- a/_source/Game.ts
+++ b/_source/Game.ts
@@ -38,8 +38,6 @@ class Game {
         // if the player character is being used for the first time, unlock its lore note
         let charNote = NotePool.unlockCharacterNote(character);
         if (charNote) {
-            // Save unlocked notes to LocalStorage
-            Save.saveNotes();
             // show the unlocked note, and then start the run when the player closes that note
             UI.fillScreen(UI.renderNote((() => Game.newRun(character)), charNote));
             return;

--- a/_source/ItemPool.ts
+++ b/_source/ItemPool.ts
@@ -82,7 +82,7 @@ class ItemPool<T extends { clone: () => T }, E> {
         // after cleaning. Otherwise, if none of the tags matched, they won't match
         // after cleaning, either.
         if (unseenMatching.length == 0) {
-            filterInPlace(seen, (k) => this.items[k].hasTags(...tags));
+            Arrays.filterInPlace(seen, (k) => this.items[k].hasTags(...tags));
             return tagsMatch;
         }
         return unseenMatching;

--- a/_source/ItemPool.ts
+++ b/_source/ItemPool.ts
@@ -90,8 +90,7 @@ class ItemPool<T extends { clone: () => T }, E> {
 
     selectAllUnseen(seen: string[], tags: E[] = [], ...fallbacks: E[][]): T[] {
         let unseen = this.selectUnseenTags(seen, tags, ...fallbacks);
-        // Note: a cast is much faster than a map((x) => x!) here
-        return unseen.map(k => this.get(k)).filter((x) => x !== null) as T[];
+        return unseen.map(k => this.get(k)).filter((x): x is T => x !== null);
     }
 
     selectRandomUnseen(seen: string[], tags: E[] = [], ...fallbacks: E[][]): T | null {
@@ -102,13 +101,12 @@ class ItemPool<T extends { clone: () => T }, E> {
     }
 
     getAll(): T[] {
-        // Note: a cast is much faster than a mapped assertion here
         if (this.sorted) {
             return this.keys.map((x) => this.items[x])
             .sort((a, b) => a.sortingNumber - b.sortingNumber)
-            .map(x => x.get()).filter((x) => x !== null) as T[];
+            .map(x => x.get()).filter((x): x is T => x !== null);
         }
-        return this.keys.map((x) => this.get(x)).filter((x) => x !== null) as T[];
+        return this.keys.map((x) => this.get(x)).filter((x): x is T => x !== null);
     }
 
 }

--- a/_source/Settings.ts
+++ b/_source/Settings.ts
@@ -1,5 +1,4 @@
 // The type that should be parsed from the JSON in LocalStorage
-// TODO: try to reify the keys of Settings so there's no duplication here
 type SettingsOptions = {
     volumePercent: number;
 };
@@ -16,29 +15,29 @@ function isSettingsOptions(x: any): x is SettingsOptions {
 }
 
 class Settings {
-    // Percentage from 0 to 100, defaulting to 100
-    private static volumePercent: number = 100;
+    private static options: SettingsOptions = {
+        // Percentage from 0 to 100, defaulting to max volume
+        volumePercent: 100
+    };
 
     public static getVolumePercent(): number {
-        return Settings.volumePercent;
+        return Settings.options.volumePercent;
     }
 
     // Set the volume percentage setting
     public static setVolumePercent(percent: number): void {
-        Settings.volumePercent = percent;
+        Settings.options.volumePercent = percent;
         SoundManager.setVolume(percent / 100);
     }
 
     // Load settings from an object and return true, if necessary properties are
     // present. If not, return false.
     public static loadFromObject(obj: SettingsOptions): void {
-        Settings.setVolumePercent(obj.volumePercent);
+        Settings.options = {...obj};
     }
 
     public static dumpToObject(): SettingsOptions {
-        return {
-            volumePercent: Settings.volumePercent
-        };
+        return {...Settings.options};
     }
 
 }

--- a/_source/app.ts
+++ b/_source/app.ts
@@ -25,8 +25,6 @@ window.onload = function() {
     Save.loadNotes();
     // unlock the tutorial at the start of the game.
     NotePool.unlockSpecificNote("Tutorial");
-    // Save unlocked notes to LocalStorage
-    Save.saveNotes();
 
     //TODO: is there any better way to do this?
     

--- a/_source/statuses/BatteryStatus.ts
+++ b/_source/statuses/BatteryStatus.ts
@@ -23,7 +23,7 @@ class BatteryStatus extends AbstractStatus {
     }
 
     @override(AbstractStatus)
-    endTurn(affected: Combatant): void {
+    endTurn(affected: Combatant, other: Combatant): void {
         this.amount--;
     }
 

--- a/_source/statuses/CountDown.ts
+++ b/_source/statuses/CountDown.ts
@@ -64,8 +64,6 @@ class CountDownStatus extends AbstractStatus {
 
     @override(AbstractStatus)
     getUtility(): number {
-        if (this.amount > 0) {
-            return 100 - this.amount;
-        }
+        return 100 - this.amount;
     }
 }

--- a/_source/statuses/CountDown.ts
+++ b/_source/statuses/CountDown.ts
@@ -24,7 +24,6 @@ class CountDownStatus extends AbstractStatus {
 
     @override(AbstractStatus)
     runsOut(user: Combatant, target: Combatant): void {
-        
         target.wound(this.damage);
 
         // if the target is still alive, the dies
@@ -34,7 +33,7 @@ class CountDownStatus extends AbstractStatus {
     }
 
     @override(AbstractStatus)
-    endTurn(affected: Combatant): void {
+    endTurn(affected: Combatant, other: Combatant): void {
         this.amount--;
     }
 

--- a/_source/statuses/DefenseStatus.ts
+++ b/_source/statuses/DefenseStatus.ts
@@ -7,7 +7,7 @@ class DefenseStatus extends AbstractStatus {
     }
 
     @override(AbstractStatus)
-    damageTakenFold(acc: number): number {
+    damageTakenFold(acc: number, affected: Combatant): number {
         return Math.max(0, acc - this.amount);
     }
 

--- a/_source/statuses/DoomedStatus.ts
+++ b/_source/statuses/DoomedStatus.ts
@@ -18,7 +18,7 @@ class DoomedStatus extends AbstractStatus {
     }
 
     @override(AbstractStatus)
-    endTurn(affected: Combatant): void {
+    endTurn(affected: Combatant, other: Combatant): void {
         this.amount--;
         if (this.amount === 0) {
             affected.actuallyDie();

--- a/_source/statuses/EnergyDebtStatus.ts
+++ b/_source/statuses/EnergyDebtStatus.ts
@@ -10,7 +10,7 @@ class EnergyDebtStatus extends AbstractStatus {
     }
 
     @override(AbstractStatus)
-    energyGainedFold(acc: number): number {
+    energyGainedFold(acc: number, affected: Combatant): number {
         if (acc >= this.amount) {
           acc -= this.amount;
           this.amount = 0;

--- a/_source/statuses/MoneybagsStatus.ts
+++ b/_source/statuses/MoneybagsStatus.ts
@@ -12,7 +12,7 @@ class MoneybagsStatus extends AbstractStatus {
     }
 
     @override(AbstractStatus)
-    damageTakenFold(acc: number): number {
+    damageTakenFold(acc: number, affected: Combatant): number {
         this.damageTaken += acc;
         return acc;
     }

--- a/_source/statuses/ShieldStatus.ts
+++ b/_source/statuses/ShieldStatus.ts
@@ -9,7 +9,7 @@ class ShieldStatus extends AbstractStatus {
     }
 
     @override(AbstractStatus)
-    damageTakenFold(acc: number): number {
+    damageTakenFold(acc: number, affected: Combatant): number {
         if (acc >= this.amount) {
           acc -= this.amount;
           this.amount = 0;

--- a/_source/statuses/StrengthStatus.ts
+++ b/_source/statuses/StrengthStatus.ts
@@ -7,7 +7,7 @@ class StrengthStatus extends AbstractStatus {
     }
 
     @override(AbstractStatus)
-    damageDealtFold(acc: number): number {
+    damageDealtFold(acc: number, affected: Combatant): number {
         return Math.max(1, acc + this.amount);
     }
 

--- a/_source/util.ts
+++ b/_source/util.ts
@@ -1,8 +1,9 @@
 // Enforces that a method is overriden from the superclass
 // Used as an annotation: @override(superclass)
 const override = <S>(superclass: { prototype: S }) =>
-    <K extends keyof S, P extends Pick<S, K>>(
-        proto: P,
+    <K extends keyof S, C extends S[K]>(
+        proto: Pick<S, K>,
         fields: K,
-        descr: TypedPropertyDescriptor<S[K]>,
+        descr: TypedPropertyDescriptor<C>,
     ) => { }
+

--- a/_source/util.ts
+++ b/_source/util.ts
@@ -1,22 +1,3 @@
-function appendText(text: string, node: HTMLElement = document.body): void {
-    const textnode = document.createTextNode(text);
-    node.appendChild(textnode);
-}
-
-// Filter an array in-place
-function filterInPlace<T>(arr: T[], pred: (x: T) => boolean): void {
-    let i = 0;
-    let j = 0;
-    while(i < arr.length) {
-        const x = arr[i];
-        if (pred(x)) {
-            arr[j++] = x;
-        }
-        i++;
-    }
-    arr.length = j;
-}
-
 // Enforces that a method is overriden from the superclass
 // Used as an annotation: @override(superclass)
 const override = <S>(superclass: { prototype: S }) =>


### PR DESCRIPTION
Move most functions in `util.ts` to more appropriate places, clean up `Settings` to not reduplicate all of the keys twice, and remove unnecessary load/save instructions with respect to note unlocking.