### PR TITLE
Add demo build to gh-pages

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -10,5 +10,3 @@ _source/tools.ts
 _source/traits.ts
 _source/predicates.ts
 _source/NoteResources.ts
-
-!dist/*

--- a/.travis.yml
+++ b/.travis.yml
@@ -10,8 +10,8 @@ script:
 - npm run build-all
 
 before_deploy:
-- scripts/before_deploy/make_dist.sh
-- scripts/before_deploy/build_demo.sh
+- "scripts/before_deploy/make_dist.sh dist"
+- "scripts/before_deploy/build_demo.sh dist gh-pages"
 
 deploy:
   provider: pages
@@ -24,3 +24,4 @@ deploy:
     branch: master
   target_branch: gh-pages
   local_dir: dist
+

--- a/.travis.yml
+++ b/.travis.yml
@@ -10,11 +10,8 @@ script:
 - npm run build-all
 
 before_deploy:
-- "mkdir dist"
-- "cp built.js dist"
-- "cp *.html dist"
-- "cp *.css dist"
-- "cp -R assets dist"
+- scripts/before_deploy/make_dist.sh
+- scripts/before_deploy/build_demo.sh
 
 deploy:
   provider: pages

--- a/package.json
+++ b/package.json
@@ -19,8 +19,9 @@
     "typescript": "^3.6.4"
   },
   "scripts": {
+    "build": "npm run preprocess && npm run compile",
     "build-all": "npm run build && npm run postprocess",
-    "build": "npm run preprocess && tsc --project _source",
+    "compile": "tsc --project _source",
     "preprocess": "node _preprocess.js",
     "postprocess": "node _postprocess.js",
     "start": "node server.js"

--- a/scripts/before_deploy/build_demo.sh
+++ b/scripts/before_deploy/build_demo.sh
@@ -1,11 +1,21 @@
-git checkout refs/tags/demo
+# Attempt to check out 'demo' from gh-pages
+git fetch origin gh-pages
+git checkout FETCH_HEAD -- demo/
 
-npm run build-all
+# If it existed and succeeds, copy it into 'dist' to be deployed
+if [ $? -eq 0 ]; then
+  mv demo dist
+else
+  git checkout refs/tags/demo
 
-mkdir -p dist/demo
-cp -R assets dist/demo
-cp built.js dist/demo
-cp *.html dist/demo
-cp *.css dist/demo
+  npm run build-all
 
-git checkout -
+  mkdir -p dist/demo
+  cp -R assets dist/demo/
+  cp built.js dist/demo/
+  cp *.html dist/demo/
+  cp *.css dist/demo/
+
+  git checkout -
+fi
+

--- a/scripts/before_deploy/build_demo.sh
+++ b/scripts/before_deploy/build_demo.sh
@@ -1,0 +1,11 @@
+git checkout refs/tags/demo
+
+npm run build-all
+
+mkdir -p dist/demo
+cp -R assets dist/demo
+cp built.js dist/demo
+cp *.html dist/demo
+cp *.css dist/demo
+
+git checkout -

--- a/scripts/before_deploy/build_demo.sh
+++ b/scripts/before_deploy/build_demo.sh
@@ -1,20 +1,34 @@
+target="$1"
+
+if [ -z "$target" ]; then
+  >&2 echo "Error: no target directory provided"
+  exit 1
+fi
+
+pages_branch="$2"
+
+if [ -z "$pages_branch" ]; then
+  >&2 echo "Error: no GitHub pages branch name provided"
+  exit 1
+fi
+
 # Attempt to check out 'demo' from gh-pages
-git fetch origin gh-pages
+git fetch origin $pages_branch
 git checkout FETCH_HEAD -- demo/
 
 # If it existed and succeeds, copy it into 'dist' to be deployed
 if [ $? -eq 0 ]; then
-  mv demo dist
+  mv demo "$target"
 else
   git checkout refs/tags/demo
 
   npm run build-all
 
-  mkdir -p dist/demo
-  cp -R assets dist/demo/
-  cp built.js dist/demo/
-  cp *.html dist/demo/
-  cp *.css dist/demo/
+  mkdir -p "$target/demo"
+  cp -R assets "$target/demo/"
+  cp built.js "$target/demo/"
+  cp *.html "$target/demo/"
+  cp *.css "$target/demo/"
 
   git checkout -
 fi

--- a/scripts/before_deploy/make_dist.sh
+++ b/scripts/before_deploy/make_dist.sh
@@ -1,0 +1,5 @@
+mkdir dist
+cp -R assets dist
+cp built.js dist
+cp *.html dist
+cp *.css dist

--- a/scripts/before_deploy/make_dist.sh
+++ b/scripts/before_deploy/make_dist.sh
@@ -1,5 +1,5 @@
 mkdir dist
-cp -R assets dist
-cp built.js dist
-cp *.html dist
-cp *.css dist
+cp -R assets dist/
+cp built.js dist/
+cp *.html dist/
+cp *.css dist/

--- a/scripts/before_deploy/make_dist.sh
+++ b/scripts/before_deploy/make_dist.sh
@@ -1,5 +1,13 @@
-mkdir dist
-cp -R assets dist/
-cp built.js dist/
-cp *.html dist/
-cp *.css dist/
+# The directory to move necessary files into
+target="$1"
+
+if [ -z "$target" ]; then
+  >&2 echo "Error: no target directory provided"
+  exit 1
+fi
+
+mkdir "$1"
+cp -R assets "$1"/
+cp built.js "$1"
+cp *.html "$1"
+cp *.css "$1"


### PR DESCRIPTION
Uses the recently-created `demo` tag to build the version of the project from the demo into `dist/demo`, which would then be available at https://MayMoonsley.github.io/inheritance/demo. However, it's really annoying to rebuild it every time, so it will attempt to checkout the most recent version of `demo/` from `gh-pages` if it's already there before trying to rebuild it.

If, for some reason, the demo build needs to be updated, the easiest way is to push a manual commit to `gh-pages` making the necessary changes, and then the deploy will use that version of `demo/` instead.

Also moves Travis' `before_deploy` instructions to external scripts for cleanliness. 